### PR TITLE
Fix to get at least minimal 20080505 compatibility back

### DIFF
--- a/action.php
+++ b/action.php
@@ -317,7 +317,12 @@ class action_plugin_discussion extends DokuWiki_Action_Plugin{
         } else {
             $url = wl($ID) . '#comment_' . $cid;
         }
-        header('Location: ' . $url);
+
+        if (function_exists('send_redirect')) {
+            send_redirect($url);
+        } else {
+            header('Location: ' . $url);
+        }
         exit();
     }
 


### PR DESCRIPTION
Many people still use 20080505 as it's distributed with Debian Lenny, the current stable version of Lenny.

I just had to change that single line to not throwing ugly PHP error messages into users' faces while still working otherwise.

This also would solve an obviously common issue brought up on http://notebook.blueridgeconcepts.com/wiki/syspi_discussion as well as on http://www.dokuwiki.org/plugin:discussion.
