### PR TITLE
Changed function call from render to render_text

### DIFF
--- a/action.php
+++ b/action.php
@@ -1400,7 +1400,10 @@ class action_plugin_discussion extends DokuWiki_Action_Plugin{
      */
     protected function _render($raw) {
         if ($this->getConf('wikisyntaxok')) {
-            $xhtml = $this->render($raw);
+            // Note the warning for render_text:
+            //   "very ineffecient for small pieces of data - try not to use"
+            // in dokuwiki/inc/plugin.php
+            $xhtml = $this->render_text($raw);
         } else { // wiki syntax not allowed -> just encode special chars
             $xhtml = hsc(trim($raw));
             $xhtml = str_replace("\n", '<br />', $xhtml);


### PR DESCRIPTION
This makes the plugin API-compatible with current Dokuwiki (2016-06-26 "Elenor of Tsort"). A caveat is the warning about inefficiency of the render_text function, but this seems to work at least on a small scale.