### PR TITLE
Fix for throbber link

### DIFF
--- a/script.js
+++ b/script.js
@@ -60,7 +60,7 @@ function discussion_ajax_preview() {
         $preview.hide();
         return;
     }
-    $preview.html('<img src="'+DOKU_BASE+'/lib/images/throbber.gif" />');
+    $preview.html('<img src="'+DOKU_BASE+'lib/images/throbber.gif" />');
     $preview.show();
 
     jQuery.post(DOKU_BASE + 'lib/exe/ajax.php',


### PR DESCRIPTION
The throbber link in line 63 has an extra slash which creates a missing link.
(At least in my installation, with basedir = "/".)