### PR TITLE
Display the IP of guests to everyone removed

### DIFF
--- a/action.php
+++ b/action.php
@@ -285,7 +285,7 @@ class action_plugin_discussion extends DokuWiki_Action_Plugin{
                             msg($lang['regbadmail'], -1);
                             return;
                         } else {
-                            $comment['user']['id'] = 'test'.hsc($_REQUEST['user']);
+                            $comment['user']['id'] = 'GUEST: '.hsc($_REQUEST['name']);
                             $comment['user']['name'] = hsc($_REQUEST['name']);
                             $comment['user']['mail'] = hsc($_REQUEST['mail']);
                         }


### PR DESCRIPTION
I applied the patch like in https://www.dokuwiki.org/plugin:discussion#removing_the_shown_ip_of_a_guest_comment_and_replacing_it_with_guestname described to remove the IP of guests. As the IP is treated as personal data, the IP really shouldn't be visible to everyone.