### PR TITLE
Fix #249 "Warning appears after upgrading to php 7.2"

### DIFF
--- a/action.php
+++ b/action.php
@@ -422,7 +422,7 @@ class action_plugin_discussion extends DokuWiki_Action_Plugin{
         }
 
         // show discussion wrapper only on certain circumstances
-        $cnt = count($data['comments']);
+        $cnt = empty($data['comments']) ? 0 : count($data['comments']);
         $keys = @array_keys($data['comments']);
         $show = false;
         if($cnt > 1 || ($cnt == 1 && $data['comments'][$keys[0]]['show'] == 1) || $this->getConf('allowguests') || isset($_SERVER['REMOTE_USER'])) {


### PR DESCRIPTION
I implemented the fix suggested in Issue #249 and it works for me in PHP 7.2. I don't see any other issues relating to PHP 7.2 versus older versions.