### PR TITLE
Update threads.php (fix for blank page)

### DIFF
--- a/syntax/threads.php
+++ b/syntax/threads.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Discussion Plugin, threads component: displays a list of recently active discussions


### PR DESCRIPTION
removed the leading blank line, thus fixing the following error:
```
Apr 23 15:56:52 server pool www7.3[8528]: PHP Warning:  Cannot modify header information - headers already sent by (output started at /var/www/wiki.magenbrot.net/lib/plugins/discussion/syntax/threads.php:2) in /var/www/wiki.magenbrot.net/inc/common.php on line 1943
```

Fixes: #288