### PR TITLE
add delimiter for preg_match at line 378

### DIFF
--- a/action.php
+++ b/action.php
@@ -375,7 +375,7 @@ class action_plugin_discussion extends DokuWiki_Action_Plugin{
         if($this->getConf('excluded_ns') == '') {
             $isNamespaceExcluded = false;
         } else {
-            $isNamespaceExcluded = preg_match($this->getConf('excluded_ns'), $INFO['namespace']);
+            $isNamespaceExcluded = preg_match("/".$this->getConf('excluded_ns')."/", $INFO['namespace']);
         }
 
         if($this->getConf('automatic')) {


### PR DESCRIPTION
Repair the following error in log : AH01071: Got error 'PHP message: PHP Warning: preg_match(): Delimiter must not be alphanumeric or backslash in /var/www/html/dokuwiki/lib/plugins/discussion/action.php on line 378
infos : https://github.com/dokufreaks/plugin-discussion/issues/293