### PR TITLE
Check if `$data['comments']` is an array before trying to get the keys

### DIFF
--- a/action.php
+++ b/action.php
@@ -416,7 +416,10 @@ class action_plugin_discussion extends DokuWiki_Action_Plugin{
 
         // show discussion wrapper only on certain circumstances
         $cnt = empty($data['comments']) ? 0 : count($data['comments']);
-        $keys = @array_keys($data['comments']);
+        $keys = [];
+        if (is_array($data['comments'])){
+            $keys = @array_keys($data['comments']);
+        }
         $show = false;
         if($cnt > 1 || ($cnt == 1 && $data['comments'][$keys[0]]['show'] == 1) || $this->getConf('allowguests') || isset($_SERVER['REMOTE_USER'])) {
             $show = true;


### PR DESCRIPTION
`$data['comments']` could be `null`...

close #320